### PR TITLE
Fix: Ensure content on internal pages is visible below header

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,7 +21,7 @@ const Index = () => {
         <div className="flex-1 flex flex-col overflow-hidden min-w-0">
           <MobileHeader />
           
-          <main className="flex-1 overflow-auto p-2 sm:p-4 md:p-6 bg-slate-50">
+          <main className="flex-1 overflow-auto p-2 sm:p-4 md:p-6 bg-slate-50 pt-12 sm:pt-14">
             <div className="max-w-7xl mx-auto space-y-3 sm:space-y-4 md:space-y-6">
               <div className="flex flex-col space-y-2 sm:space-y-3 md:space-y-0 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-1">

--- a/src/pages/clients/ClientsPage.tsx
+++ b/src/pages/clients/ClientsPage.tsx
@@ -24,7 +24,7 @@ const ClientsPage = () => {
         <div className="flex-1 flex flex-col overflow-hidden min-w-0">
           <MobileHeader />
           
-          <main className="flex-1 overflow-auto p-2 sm:p-4 md:p-6 bg-slate-50">
+          <main className="flex-1 overflow-auto p-2 sm:p-4 md:p-6 bg-slate-50 pt-12 sm:pt-14">
             <div className="max-w-7xl mx-auto space-y-3 sm:space-y-4 md:space-y-6">
               <div className="flex flex-col space-y-2 sm:space-y-3 md:space-y-0 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-1">

--- a/src/pages/sessions/SessionsPage.tsx
+++ b/src/pages/sessions/SessionsPage.tsx
@@ -26,7 +26,7 @@ const SessionsPage = () => {
         <div className="flex-1 flex flex-col overflow-hidden min-w-0">
           <Header />
           
-          <main className="flex-1 overflow-auto p-3 md:p-6 bg-slate-50">
+          <main className="flex-1 overflow-auto p-3 md:p-6 bg-slate-50 pt-12 md:pt-14">
             <div className="max-w-7xl mx-auto space-y-4 md:space-y-6">
               <div className="flex flex-col space-y-3 md:space-y-0 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-1">

--- a/src/pages/user/SettingsPage.tsx
+++ b/src/pages/user/SettingsPage.tsx
@@ -61,7 +61,7 @@ const SettingsPage = () => {
         <div className="flex-1 flex flex-col overflow-hidden">
           <Header />
           
-          <main className="flex-1 overflow-auto p-6 bg-slate-50">
+          <main className="flex-1 overflow-auto p-6 bg-slate-50 pt-12 md:pt-14">
             <div className="max-w-4xl mx-auto space-y-6">
               <div>
                 <h1 className="text-2xl font-display font-semibold text-gray-900">{t('settings.title')}</h1>


### PR DESCRIPTION
Problem:
Following a previous update, internal pages (Dashboard, Clients, etc.) rendered blank content below the Navbar/Header. The Dashboard page specifically required a scroll interaction to reveal content. This was caused by the main content area rendering underneath the sticky header components.

Solution:
1.  I added appropriate top padding to the `main` element in key internal pages to offset the height of their respective sticky headers:
    - `src/pages/Index.tsx`: Added `pt-12 sm:pt-14` to account for `MobileHeader`.
    - `src/pages/clients/ClientsPage.tsx`: Added `pt-12 sm:pt-14` for `MobileHeader`.
    - `src/pages/sessions/SessionsPage.tsx`: Added `pt-12 md:pt-14` for `Header`.
    - `src/pages/user/SettingsPage.tsx`: Added `pt-12 md:pt-14` for `Header`.

2.  I verified that no explicit JavaScript-based scroll-to-reveal mechanisms were causing the content visibility issues. The scroll-dependent behavior was likely a symptom of the layout overlap.

3.  I confirmed that no CSS classes like `hidden sm:block` or `h-0` were unintentionally hiding main content areas on mobile by default.

These changes ensure that the content on internal pages is correctly positioned below the header, making it immediately visible on page load and resolving the blank content and scroll-to-reveal issues. The landing page remains unaffected.